### PR TITLE
sendRequest/Reset/Change password logic

### DIFF
--- a/src/main/java/ru/leti/wise/task/profile/error/ErrorCode.java
+++ b/src/main/java/ru/leti/wise/task/profile/error/ErrorCode.java
@@ -3,5 +3,6 @@ package ru.leti.wise.task.profile.error;
 public enum ErrorCode {
     PROFILE_NOT_FOUND,
     INVALID_PASSWORD,
-
+    EMAIL_ALREADY_TAKEN,
+    UNKNOWN_LINK,
 }

--- a/src/main/java/ru/leti/wise/task/profile/error/GrpcErrorHandler.java
+++ b/src/main/java/ru/leti/wise/task/profile/error/GrpcErrorHandler.java
@@ -11,6 +11,8 @@ public class GrpcErrorHandler {
         return switch (e.getErrorCode()) {
             case PROFILE_NOT_FOUND -> Status.NOT_FOUND;
             case INVALID_PASSWORD -> Status.UNAUTHENTICATED;
+            case EMAIL_ALREADY_TAKEN -> Status.ALREADY_EXISTS;
+            case UNKNOWN_LINK -> Status.INVALID_ARGUMENT;
             default -> Status.UNKNOWN;
         };
     }

--- a/src/main/java/ru/leti/wise/task/profile/logic/ChangePasswordOperation.java
+++ b/src/main/java/ru/leti/wise/task/profile/logic/ChangePasswordOperation.java
@@ -1,0 +1,33 @@
+package ru.leti.wise.task.profile.logic;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import ru.leti.wise.task.profile.error.BusinessException;
+import ru.leti.wise.task.profile.error.ErrorCode;
+import ru.leti.wise.task.profile.model.ProfileEntity;
+import ru.leti.wise.task.profile.mapper.ProfileMapper;
+import ru.leti.wise.task.profile.repository.ProfileRepository;
+import ru.leti.wise.task.profile.ProfileGrpc;
+import ru.leti.wise.task.profile.ProfileGrpc.ChangePasswordRequest;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ChangePasswordOperation {
+    private final ProfileMapper profileMapper;
+    private final ProfileRepository profileRepository;
+
+    public void activate(ChangePasswordRequest request) {
+        ProfileEntity profile = profileRepository.findById(UUID.fromString(request.getProfileId())).orElseThrow(
+                () -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
+
+        if (!BCrypt.checkpw(request.getOldPassword(),profile.getProfilePassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        profile.setProfilePassword(BCrypt.hashpw(request.getNewPassword(), BCrypt.gensalt()));
+        profileRepository.save(profile);
+    }
+}

--- a/src/main/java/ru/leti/wise/task/profile/logic/ResetPasswordOperation.java
+++ b/src/main/java/ru/leti/wise/task/profile/logic/ResetPasswordOperation.java
@@ -1,0 +1,42 @@
+package ru.leti.wise.task.profile.logic;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Component;
+import ru.leti.wise.task.profile.ProfileGrpc;
+import ru.leti.wise.task.profile.ProfileGrpc.ResetPasswordRequest;
+import ru.leti.wise.task.profile.error.BusinessException;
+import ru.leti.wise.task.profile.error.ErrorCode;
+import ru.leti.wise.task.profile.mapper.ProfileMapper;
+import ru.leti.wise.task.profile.model.PasswordRecoveryEntity;
+import ru.leti.wise.task.profile.model.ProfileEntity;
+import ru.leti.wise.task.profile.repository.PasswordRecoveryRepository;
+import ru.leti.wise.task.profile.repository.ProfileRepository;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ResetPasswordOperation {
+
+    private final ProfileRepository profileRepository;
+    private final ProfileMapper profileMapper;
+    private final PasswordRecoveryRepository passwordRecoveryRepository;
+
+    public ProfileGrpc.ResetPasswordResponse activate(ResetPasswordRequest resetPasswordRequest) {
+        PasswordRecoveryEntity passwordRecoveryEntity = passwordRecoveryRepository
+                .findFirstByRecoveryTokenOrderByExpiresAtDesc(UUID.fromString(resetPasswordRequest.getRecoveryToken()))
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNKNOWN_LINK));
+
+        ProfileEntity profile = profileRepository.findByEmail(passwordRecoveryEntity.getEmail()).orElseThrow(
+                () -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
+
+        profile.setProfilePassword(BCrypt.hashpw(resetPasswordRequest.getNewPassword(), BCrypt.gensalt()));
+        profileRepository.save(profile);
+        passwordRecoveryRepository.delete(passwordRecoveryEntity);
+        return ProfileGrpc.ResetPasswordResponse.newBuilder()
+                .setProfile(profileMapper.toProfile(profile))
+                .build();
+    }
+}
+

--- a/src/main/java/ru/leti/wise/task/profile/logic/SendResetPasswordEmailOperation.java
+++ b/src/main/java/ru/leti/wise/task/profile/logic/SendResetPasswordEmailOperation.java
@@ -1,0 +1,63 @@
+package ru.leti.wise.task.profile.logic;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+import ru.leti.wise.task.profile.error.BusinessException;
+import ru.leti.wise.task.profile.error.ErrorCode;
+import ru.leti.wise.task.profile.ProfileGrpc.SendResetPasswordEmailRequest;
+import ru.leti.wise.task.profile.model.PasswordRecoveryEntity;
+import ru.leti.wise.task.profile.model.ProfileEntity;
+import ru.leti.wise.task.profile.notification.MailSender;
+import ru.leti.wise.task.profile.repository.PasswordRecoveryRepository;
+import ru.leti.wise.task.profile.repository.ProfileRepository;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class SendResetPasswordEmailOperation {
+    private final String RECOVERY_LINK = "https://wisetask.ru/profile/reset_password?token=";
+
+    private final MailSender mailSender;
+    private final ProfileRepository profileRepository;
+    private final PasswordRecoveryRepository passwordRecoveryRepository;
+
+
+    private final String emailSubject = "Ваша ссылка для восстановления пароля";
+
+    private String createEmailText(String recoveryToken) {
+        return "Тема: Восстановление доступа к вашему аккаунту\n\n" +
+               "Здравствуйте!\n\n" +
+               "Вы запросили сброс пароля для wise-task.\n\n" +
+               "Для установки нового пароля перейдите по ссылке:\n" +
+               RECOVERY_LINK + recoveryToken + "\n\n" +
+               "Ссылка будет активна в течение 10 минут.\n" +
+               "Если вы не запрашивали сброс пароля, проигнорируйте это письмо.\n\n" +
+               "С уважением,\n" +
+               "Команда wise-task";
+    }
+
+
+    public void activate(SendResetPasswordEmailRequest request) {
+        ProfileEntity profile = profileRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
+
+        passwordRecoveryRepository.deleteAllByEmail(profile.getEmail());
+
+        UUID recoveryToken = UUID.randomUUID();
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(10);
+
+        PasswordRecoveryEntity passwordRecoveryEntity = new PasswordRecoveryEntity();
+        passwordRecoveryEntity.setEmail(request.getEmail());
+        passwordRecoveryEntity.setRecoveryToken(recoveryToken);
+        passwordRecoveryEntity.setExpiresAt(Timestamp.valueOf(expiresAt));
+        passwordRecoveryRepository.save(passwordRecoveryEntity);
+
+
+        mailSender.sendEmail(profile.getEmail(), emailSubject, createEmailText(recoveryToken.toString()));
+    }
+}

--- a/src/main/java/ru/leti/wise/task/profile/logic/SignInOperation.java
+++ b/src/main/java/ru/leti/wise/task/profile/logic/SignInOperation.java
@@ -1,6 +1,7 @@
 package ru.leti.wise.task.profile.logic;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.stereotype.Component;
 import ru.leti.wise.task.profile.ProfileGrpc.SignInRequest;
 import ru.leti.wise.task.profile.ProfileGrpc.SignInResponse;
@@ -22,7 +23,7 @@ public class SignInOperation {
         ProfileEntity profile = profileRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
 
-        if (!profile.getProfilePassword().equals(request.getPassword())) {
+        if (!BCrypt.checkpw(request.getPassword(),profile.getProfilePassword())) {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
 

--- a/src/main/java/ru/leti/wise/task/profile/logic/SignUpOperation.java
+++ b/src/main/java/ru/leti/wise/task/profile/logic/SignUpOperation.java
@@ -1,9 +1,12 @@
 package ru.leti.wise.task.profile.logic;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.stereotype.Component;
 import ru.leti.wise.task.profile.ProfileGrpc.SignUpRequest;
 import ru.leti.wise.task.profile.ProfileGrpc.SignUpResponse;
+import ru.leti.wise.task.profile.error.BusinessException;
+import ru.leti.wise.task.profile.error.ErrorCode;
 import ru.leti.wise.task.profile.mapper.ProfileMapper;
 import ru.leti.wise.task.profile.model.ProfileEntity;
 import ru.leti.wise.task.profile.repository.ProfileRepository;
@@ -18,8 +21,12 @@ public class SignUpOperation {
     private final ProfileRepository profileRepository;
 
     public SignUpResponse activate(SignUpRequest signUpRequest) {
+        if (!profileRepository.findByEmail(signUpRequest.getProfile().getEmail()).isEmpty()){
+            throw new BusinessException(ErrorCode.EMAIL_ALREADY_TAKEN);
+        }
         ProfileEntity profile = profileMapper.toProfileEntity(signUpRequest.getProfile());
         profile.setId(UUID.randomUUID());
+        profile.setProfilePassword(BCrypt.hashpw(profile.getProfilePassword(), BCrypt.gensalt()));
         profileRepository.save(profile);
         return SignUpResponse.newBuilder()
                 .setProfile(profileMapper.toProfile(profile))

--- a/src/main/java/ru/leti/wise/task/profile/mapper/ProfileMapper.java
+++ b/src/main/java/ru/leti/wise/task/profile/mapper/ProfileMapper.java
@@ -1,8 +1,6 @@
 package ru.leti.wise.task.profile.mapper;
 
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.NullValueCheckStrategy;
+import org.mapstruct.*;
 import ru.leti.wise.task.profile.ProfileOuterClass;
 import ru.leti.wise.task.profile.ProfileOuterClass.Profile;
 import ru.leti.wise.task.profile.model.ProfileEntity;
@@ -13,9 +11,11 @@ import java.util.List;
 @Mapper(componentModel = "spring", nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
 public interface ProfileMapper {
 
-
     @Mapping(target = "profilePassword", ignore = true)
     Profile toProfile(ProfileEntity profile);
+
+    @Mapping(target = "id",
+            conditionExpression = "java(profile.getId() != null && !profile.getId().isEmpty())", defaultExpression = "java(null)")
     ProfileEntity toProfileEntity(Profile profile);
 
     List<Profile> toProfiles(List<ProfileEntity> profiles);

--- a/src/main/java/ru/leti/wise/task/profile/model/PasswordRecoveryEntity.java
+++ b/src/main/java/ru/leti/wise/task/profile/model/PasswordRecoveryEntity.java
@@ -1,0 +1,24 @@
+package ru.leti.wise.task.profile.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+@Data
+@Entity
+@Table(name = "password_recovery")
+public class PasswordRecoveryEntity {
+
+    @Id
+    @Column(name = "recovery_token")
+    UUID recoveryToken;
+
+    @Column(name = "email")
+    String email;
+
+
+    @Column(name = "expires_at")
+    Timestamp expiresAt;
+}

--- a/src/main/java/ru/leti/wise/task/profile/notification/MailSender.java
+++ b/src/main/java/ru/leti/wise/task/profile/notification/MailSender.java
@@ -1,0 +1,40 @@
+package ru.leti.wise.task.profile.notification;
+
+
+import java.time.LocalDateTime;
+import java.util.Properties;
+import jakarta.mail.*;
+import jakarta.mail.internet.*;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MailSender {
+
+    private final String smtpHost = "smtp.wise task.ru" ;
+    private final int smtpPort = 25;
+    private final String fromAddress = "noreply@wisetask.ru";
+
+
+    public void sendEmail(String toAddress, String subject, String messageText) {
+        Properties props = new Properties();
+        props.put("mail.smtp.host", smtpHost);
+        props.put("mail.smtp.port", String.valueOf(smtpPort));
+        props.put("mail.smtp.auth", "false");
+        props.put("mail.smtp.starttls.enable", "false");
+
+        Session session = Session.getInstance(props);
+
+        try {
+            Message message = new MimeMessage(session);
+            message.setFrom(new InternetAddress(fromAddress));
+            message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(toAddress));
+            message.setSubject(subject);
+            message.setText(messageText);
+            Transport.send(message);
+        } catch (MessagingException e){
+
+        }
+        System.out.println(LocalDateTime.now() + "Письмо для" + toAddress + "успешно отправлено!");
+    }
+}
+

--- a/src/main/java/ru/leti/wise/task/profile/notification/MailSender.java
+++ b/src/main/java/ru/leti/wise/task/profile/notification/MailSender.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class MailSender {
 
-    private final String smtpHost = "smtp.wise task.ru" ;
+    private final String smtpHost = "smtp.wisetask.ru" ;
     private final int smtpPort = 25;
     private final String fromAddress = "noreply@wisetask.ru";
 

--- a/src/main/java/ru/leti/wise/task/profile/repository/PasswordRecoveryRepository.java
+++ b/src/main/java/ru/leti/wise/task/profile/repository/PasswordRecoveryRepository.java
@@ -1,0 +1,18 @@
+package ru.leti.wise.task.profile.repository;
+
+import io.micrometer.observation.annotation.Observed;
+import org.springframework.data.repository.CrudRepository;
+import ru.leti.wise.task.profile.model.PasswordRecoveryEntity;
+
+import java.util.Optional;
+import java.util.UUID;
+
+
+@Observed
+public interface PasswordRecoveryRepository extends CrudRepository<PasswordRecoveryEntity, UUID> {
+
+
+    Optional<PasswordRecoveryEntity> findFirstByRecoveryTokenOrderByExpiresAtDesc(UUID recoveryToken);
+    void deleteAllByEmail(String email);
+
+}

--- a/src/main/java/ru/leti/wise/task/profile/service/grpc/ProfileGrpcService.java
+++ b/src/main/java/ru/leti/wise/task/profile/service/grpc/ProfileGrpcService.java
@@ -21,12 +21,15 @@ import java.util.UUID;
 
 @Slf4j
 @Observed
-@GRpcService(interceptors = { LogInterceptor.class })
+@GRpcService(interceptors = {LogInterceptor.class})
 @RequiredArgsConstructor
 public class ProfileGrpcService extends ProfileServiceImplBase {
 
     private final SignUpOperation signUpOperation;
     private final SignInOperation signInOperation;
+    private final SendResetPasswordEmailOperation sendResetPasswordEmailOperation;
+    private final ResetPasswordOperation resetPasswordOperation;
+    private final ChangePasswordOperation changePasswordOperation;
     private final GetProfileOperation getProfileOperation;
     private final DeleteProfileOperation deleteProfileOperation;
     private final UpdateProfileOperation updateProfileOperation;
@@ -70,6 +73,26 @@ public class ProfileGrpcService extends ProfileServiceImplBase {
     }
 
     @Override
+    public void sendResetPasswordEmail(SendResetPasswordEmailRequest request, StreamObserver<Empty> responseObserver) {
+        sendResetPasswordEmailOperation.activate(request);
+        responseObserver.onNext(Empty.newBuilder().build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void resetPassword(ResetPasswordRequest request, StreamObserver<ResetPasswordResponse> responseObserver) {
+        responseObserver.onNext(resetPasswordOperation.activate(request));
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void changePassword(ChangePasswordRequest request, StreamObserver<Empty> responseObserver) {
+        changePasswordOperation.activate(request);
+        responseObserver.onNext(Empty.newBuilder().build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
     public void getAllProfiles(Empty request, StreamObserver<GetAllProfilesResponse> responseObserver) {
         responseObserver.onNext(getAllProfilesOperation.activate());
         responseObserver.onCompleted();
@@ -80,6 +103,7 @@ public class ProfileGrpcService extends ProfileServiceImplBase {
         responseObserver.onNext(getProfileByEmailOperation.activate(request.getEmail()));
         responseObserver.onCompleted();
     }
+
 
     @GRpcServiceAdvice
     @RequiredArgsConstructor

--- a/src/main/resources/proto/profile_grpc.proto
+++ b/src/main/resources/proto/profile_grpc.proto
@@ -9,6 +9,9 @@ import "google/protobuf/empty.proto";
 service ProfileService {
   rpc SignUp(SignUpRequest) returns (SignUpResponse);
   rpc SignIn(SignInRequest) returns (SignInResponse);
+  rpc SendResetPasswordEmail(SendResetPasswordEmailRequest) returns (google.protobuf.Empty);
+  rpc ResetPassword(ResetPasswordRequest) returns (ResetPasswordResponse);
+  rpc ChangePassword(ChangePasswordRequest) returns (google.protobuf.Empty);
   rpc GetAllProfiles(google.protobuf.Empty) returns (GetAllProfilesResponse);
   rpc GetProfile(GetProfileRequest) returns (GetProfileResponse);
   rpc GetProfileByEmail(GetProfileByEmailRequest) returns (GetProfileByEmailResponse);
@@ -67,6 +70,26 @@ message SignInRequest {
 }
 
 message SignInResponse {
+  Profile profile = 1;
+}
+
+message ChangePasswordRequest{
+  string profile_id = 1;
+  string oldPassword = 2;
+  string newPassword = 3;
+}
+
+message SendResetPasswordEmailRequest{
+  string email = 1;
+}
+
+message ResetPasswordRequest{
+  string recovery_token = 1;
+  string new_password = 2;
+}
+
+
+message ResetPasswordResponse{
   Profile profile = 1;
 }
 


### PR DESCRIPTION
fix!: add null/empty check for ProfileMapper.Id field

feat: implement password reset flow
- add send reset request endpoint (gRPC/GraphQL)
- add password change endpoint (gRPC/GraphQL)
- add password_recovery table schema (UUID token, email, expires_at)
- implement token validation against database
- introduce new ErrorCode cases for auth failures

refactor(db):
- add flyway migration V1__create_password_recovery_table.sql