### PR TITLE
validation for profiles + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+.gradle
+.idea

--- a/src/main/java/ru/leti/wise/task/profile/error/ErrorCode.java
+++ b/src/main/java/ru/leti/wise/task/profile/error/ErrorCode.java
@@ -1,8 +1,17 @@
 package ru.leti.wise.task.profile.error;
 
+import lombok.Getter;
+
+@Getter
 public enum ErrorCode {
-    PROFILE_NOT_FOUND,
-    INVALID_PASSWORD,
-    EMAIL_ALREADY_TAKEN,
-    UNKNOWN_LINK,
+    PROFILE_NOT_FOUND("Профиль не найден"),
+    INVALID_PASSWORD("Неправильный пароль"),
+    EMAIL_ALREADY_TAKEN("Пользователь с данной электронной почтой уже существует"),
+    UNKNOWN_LINK("Некорректный токен"),
+    EMPTY_FIELDS("Не все поля заполнены");
+    final String message;
+
+    ErrorCode(String message) {
+        this.message = message;
+    }
 }

--- a/src/main/java/ru/leti/wise/task/profile/error/GrpcErrorHandler.java
+++ b/src/main/java/ru/leti/wise/task/profile/error/GrpcErrorHandler.java
@@ -8,11 +8,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class GrpcErrorHandler {
     public Status processError(BusinessException e) {
+        String message = e.getErrorCode().getMessage();
         return switch (e.getErrorCode()) {
-            case PROFILE_NOT_FOUND -> Status.NOT_FOUND;
-            case INVALID_PASSWORD -> Status.UNAUTHENTICATED;
-            case EMAIL_ALREADY_TAKEN -> Status.ALREADY_EXISTS;
-            case UNKNOWN_LINK -> Status.INVALID_ARGUMENT;
+            case PROFILE_NOT_FOUND -> Status.NOT_FOUND.withDescription(message);
+            case INVALID_PASSWORD -> Status.UNAUTHENTICATED.withDescription(message);
+            case EMAIL_ALREADY_TAKEN -> Status.ALREADY_EXISTS.withDescription(message);
+            case UNKNOWN_LINK, EMPTY_FIELDS -> Status.INVALID_ARGUMENT.withDescription(message);
             default -> Status.UNKNOWN;
         };
     }

--- a/src/main/java/ru/leti/wise/task/profile/logic/ChangePasswordOperation.java
+++ b/src/main/java/ru/leti/wise/task/profile/logic/ChangePasswordOperation.java
@@ -10,20 +10,19 @@ import ru.leti.wise.task.profile.mapper.ProfileMapper;
 import ru.leti.wise.task.profile.repository.ProfileRepository;
 import ru.leti.wise.task.profile.ProfileGrpc;
 import ru.leti.wise.task.profile.ProfileGrpc.ChangePasswordRequest;
+import ru.leti.wise.task.profile.validation.ProfileValidator;
 
 import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
 public class ChangePasswordOperation {
-    private final ProfileMapper profileMapper;
     private final ProfileRepository profileRepository;
+    private final ProfileValidator profileValidator;
 
     public void activate(ChangePasswordRequest request) {
-        ProfileEntity profile = profileRepository.findById(UUID.fromString(request.getProfileId())).orElseThrow(
-                () -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
-
-        if (!BCrypt.checkpw(request.getOldPassword(),profile.getProfilePassword())) {
+        ProfileEntity profile = profileValidator.checkForExistence(request.getProfileId());
+        if (!BCrypt.checkpw(request.getOldPassword(), profile.getProfilePassword())) {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
 

--- a/src/main/java/ru/leti/wise/task/profile/logic/DeleteProfileOperation.java
+++ b/src/main/java/ru/leti/wise/task/profile/logic/DeleteProfileOperation.java
@@ -2,7 +2,9 @@ package ru.leti.wise.task.profile.logic;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import ru.leti.wise.task.profile.ProfileGrpc.DeleteProfileRequest;
 import ru.leti.wise.task.profile.repository.ProfileRepository;
+import ru.leti.wise.task.profile.validation.ProfileValidator;
 
 import java.util.UUID;
 
@@ -11,8 +13,11 @@ import java.util.UUID;
 public class DeleteProfileOperation {
 
     private final ProfileRepository profileRepository;
+    private final ProfileValidator profileValidator;
 
-    public void activate(UUID id) {
-        profileRepository.deleteById(id);
+    public void activate(DeleteProfileRequest request) {
+        profileValidator.checkForExistence(request.getProfileId());
+        var uuid = UUID.fromString(request.getProfileId());
+        profileRepository.deleteById(uuid);
     }
 }

--- a/src/main/java/ru/leti/wise/task/profile/logic/GetProfileByEmailOperation.java
+++ b/src/main/java/ru/leti/wise/task/profile/logic/GetProfileByEmailOperation.java
@@ -7,18 +7,17 @@ import ru.leti.wise.task.profile.error.BusinessException;
 import ru.leti.wise.task.profile.error.ErrorCode;
 import ru.leti.wise.task.profile.mapper.ProfileMapper;
 import ru.leti.wise.task.profile.repository.ProfileRepository;
+import ru.leti.wise.task.profile.validation.ProfileValidator;
 
 @Component
 @RequiredArgsConstructor
 public class GetProfileByEmailOperation {
 
     private final ProfileMapper profileMapper;
-    private final ProfileRepository profileRepository;
+    private final ProfileValidator profileValidator;
 
     public ProfileGrpc.GetProfileByEmailResponse activate(String email) {
-        var profile = profileRepository.findByEmail(email)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
-
+        var profile = profileValidator.checkEmailExistence(email);
         return ProfileGrpc.GetProfileByEmailResponse.newBuilder()
                 .setProfile(profileMapper.toProfile(profile))
                 .build();

--- a/src/main/java/ru/leti/wise/task/profile/logic/GetProfileOperation.java
+++ b/src/main/java/ru/leti/wise/task/profile/logic/GetProfileOperation.java
@@ -2,11 +2,13 @@ package ru.leti.wise.task.profile.logic;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import ru.leti.wise.task.profile.ProfileGrpc.GetProfileRequest;
 import ru.leti.wise.task.profile.ProfileGrpc.GetProfileResponse;
 import ru.leti.wise.task.profile.error.BusinessException;
 import ru.leti.wise.task.profile.error.ErrorCode;
 import ru.leti.wise.task.profile.mapper.ProfileMapper;
 import ru.leti.wise.task.profile.repository.ProfileRepository;
+import ru.leti.wise.task.profile.validation.ProfileValidator;
 
 import java.util.UUID;
 
@@ -15,11 +17,10 @@ import java.util.UUID;
 public class GetProfileOperation {
 
     private final ProfileMapper profileMapper;
-    private final ProfileRepository profileRepository;
+    private final ProfileValidator profileValidator;
 
-    public GetProfileResponse activate(UUID id) {
-        var profile = profileRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
+    public GetProfileResponse activate(GetProfileRequest request) {
+        var profile = profileValidator.checkForExistence(request.getProfileId());
 
         return GetProfileResponse.newBuilder()
                 .setProfile(profileMapper.toProfile(profile))

--- a/src/main/java/ru/leti/wise/task/profile/logic/SendResetPasswordEmailOperation.java
+++ b/src/main/java/ru/leti/wise/task/profile/logic/SendResetPasswordEmailOperation.java
@@ -12,6 +12,7 @@ import ru.leti.wise.task.profile.model.ProfileEntity;
 import ru.leti.wise.task.profile.notification.MailSender;
 import ru.leti.wise.task.profile.repository.PasswordRecoveryRepository;
 import ru.leti.wise.task.profile.repository.ProfileRepository;
+import ru.leti.wise.task.profile.validation.ProfileValidator;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -24,6 +25,7 @@ public class SendResetPasswordEmailOperation {
 
     private final MailSender mailSender;
     private final ProfileRepository profileRepository;
+    private final ProfileValidator profileValidator;
     private final PasswordRecoveryRepository passwordRecoveryRepository;
 
 
@@ -43,8 +45,7 @@ public class SendResetPasswordEmailOperation {
 
 
     public void activate(SendResetPasswordEmailRequest request) {
-        ProfileEntity profile = profileRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
+        ProfileEntity profile = profileValidator.checkEmailExistence(request.getEmail());
 
         passwordRecoveryRepository.deleteAllByEmail(profile.getEmail());
 

--- a/src/main/java/ru/leti/wise/task/profile/logic/SignInOperation.java
+++ b/src/main/java/ru/leti/wise/task/profile/logic/SignInOperation.java
@@ -10,20 +10,19 @@ import ru.leti.wise.task.profile.error.ErrorCode;
 import ru.leti.wise.task.profile.mapper.ProfileMapper;
 import ru.leti.wise.task.profile.model.ProfileEntity;
 import ru.leti.wise.task.profile.repository.ProfileRepository;
+import ru.leti.wise.task.profile.validation.ProfileValidator;
 
 @Component
 @RequiredArgsConstructor
 public class SignInOperation {
 
     private final ProfileMapper profileMapper;
-    private final ProfileRepository profileRepository;
-
+    private final ProfileValidator profileValidator;
     public SignInResponse activate(SignInRequest request) {
 
-        ProfileEntity profile = profileRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
+        ProfileEntity profile = profileValidator.checkEmailExistence(request.getEmail());
 
-        if (!BCrypt.checkpw(request.getPassword(),profile.getProfilePassword())) {
+        if (request.getPassword().isBlank() || !BCrypt.checkpw(request.getPassword(),profile.getProfilePassword())) {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
 

--- a/src/main/java/ru/leti/wise/task/profile/logic/SignUpOperation.java
+++ b/src/main/java/ru/leti/wise/task/profile/logic/SignUpOperation.java
@@ -10,7 +10,9 @@ import ru.leti.wise.task.profile.error.ErrorCode;
 import ru.leti.wise.task.profile.mapper.ProfileMapper;
 import ru.leti.wise.task.profile.model.ProfileEntity;
 import ru.leti.wise.task.profile.repository.ProfileRepository;
+import ru.leti.wise.task.profile.validation.ProfileValidator;
 
+import java.nio.file.attribute.UserPrincipal;
 import java.util.UUID;
 
 @Component
@@ -19,11 +21,13 @@ public class SignUpOperation {
 
     private final ProfileMapper profileMapper;
     private final ProfileRepository profileRepository;
+    private final ProfileValidator profileValidator;
 
     public SignUpResponse activate(SignUpRequest signUpRequest) {
-        if (!profileRepository.findByEmail(signUpRequest.getProfile().getEmail()).isEmpty()){
-            throw new BusinessException(ErrorCode.EMAIL_ALREADY_TAKEN);
-        }
+        var profileDto = signUpRequest.getProfile();
+        profileValidator.checkEmptyFields(profileDto);
+        profileValidator.checkUniqueEmail(profileDto);
+
         ProfileEntity profile = profileMapper.toProfileEntity(signUpRequest.getProfile());
         profile.setId(UUID.randomUUID());
         profile.setProfilePassword(BCrypt.hashpw(profile.getProfilePassword(), BCrypt.gensalt()));

--- a/src/main/java/ru/leti/wise/task/profile/mapper/ProfileMapper.java
+++ b/src/main/java/ru/leti/wise/task/profile/mapper/ProfileMapper.java
@@ -7,6 +7,7 @@ import ru.leti.wise.task.profile.model.ProfileEntity;
 import ru.leti.wise.task.profile.model.Role;
 
 import java.util.List;
+import java.util.UUID;
 
 @Mapper(componentModel = "spring", nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
 public interface ProfileMapper {
@@ -14,11 +15,17 @@ public interface ProfileMapper {
     @Mapping(target = "profilePassword", ignore = true)
     Profile toProfile(ProfileEntity profile);
 
-    @Mapping(target = "id",
-            conditionExpression = "java(profile.getId() != null && !profile.getId().isEmpty())", defaultExpression = "java(null)")
+    @Mapping(target = "id", ignore = true)
     ProfileEntity toProfileEntity(Profile profile);
 
+    @Mapping(target = "id",
+            conditionExpression = "java(profile.getId() != null && !profile.getId().isEmpty())",
+            defaultExpression = "java(mapStringToUuid(profile.getId()))")
     List<Profile> toProfiles(List<ProfileEntity> profiles);
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "profileRole", ignore = true)
+    @Mapping(target = "profilePassword", ignore = true)
+    void updateProfileEntity(@MappingTarget ProfileEntity target, Profile source);
 
     default ProfileOuterClass.Role toRole(Role role) {
         return ProfileOuterClass.Role.valueOf(role.name());
@@ -26,5 +33,13 @@ public interface ProfileMapper {
 
     default Role toRole(ProfileOuterClass.Role role) {
         return Role.valueOf(role.name());
+    }
+
+    default UUID mapStringToUuid(String value) {
+        return value != null ? UUID.fromString(value) : null;
+    }
+
+    default String mapUuidToString(UUID value) {
+        return value != null ? value.toString() : "";
     }
 }

--- a/src/main/java/ru/leti/wise/task/profile/model/PasswordRecoveryEntity.java
+++ b/src/main/java/ru/leti/wise/task/profile/model/PasswordRecoveryEntity.java
@@ -18,7 +18,6 @@ public class PasswordRecoveryEntity {
     @Column(name = "email")
     String email;
 
-
     @Column(name = "expires_at")
     Timestamp expiresAt;
 }

--- a/src/main/java/ru/leti/wise/task/profile/model/Role.java
+++ b/src/main/java/ru/leti/wise/task/profile/model/Role.java
@@ -1,8 +1,7 @@
 package ru.leti.wise.task.profile.model;
 
 public enum Role {
-    STUDENT,
-    TEACHER,
-    CAPTAIN,
+    USER,
+    AUTHOR,
     ADMIN
 }

--- a/src/main/java/ru/leti/wise/task/profile/service/grpc/ProfileGrpcService.java
+++ b/src/main/java/ru/leti/wise/task/profile/service/grpc/ProfileGrpcService.java
@@ -38,13 +38,13 @@ public class ProfileGrpcService extends ProfileServiceImplBase {
 
     @Override
     public void getProfile(GetProfileRequest request, StreamObserver<GetProfileResponse> responseObserver) {
-        responseObserver.onNext(getProfileOperation.activate(UUID.fromString(request.getProfileId())));
+        responseObserver.onNext(getProfileOperation.activate(request));
         responseObserver.onCompleted();
     }
 
     @Override
     public void deleteProfile(DeleteProfileRequest request, StreamObserver<Empty> responseObserver) {
-        deleteProfileOperation.activate(UUID.fromString(request.getProfileId()));
+        deleteProfileOperation.activate(request);
         responseObserver.onNext(Empty.newBuilder().build());
         responseObserver.onCompleted();
     }
@@ -107,6 +107,7 @@ public class ProfileGrpcService extends ProfileServiceImplBase {
 
     @GRpcServiceAdvice
     @RequiredArgsConstructor
+    @Slf4j
     static class ErrorHandler {
         private final GrpcErrorHandler grpcErrorHandler;
 

--- a/src/main/java/ru/leti/wise/task/profile/validation/ProfileValidator.java
+++ b/src/main/java/ru/leti/wise/task/profile/validation/ProfileValidator.java
@@ -1,0 +1,62 @@
+package ru.leti.wise.task.profile.validation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import ru.leti.wise.task.profile.ProfileOuterClass.Profile;
+import ru.leti.wise.task.profile.error.BusinessException;
+import ru.leti.wise.task.profile.error.ErrorCode;
+import ru.leti.wise.task.profile.model.ProfileEntity;
+import ru.leti.wise.task.profile.repository.ProfileRepository;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileValidator {
+
+    private final ProfileRepository profileRepository;
+    public void checkEmptyFields(Profile profile){
+        if(profile.getEmail().isBlank() || profile.getProfilePassword().isBlank()
+                || profile.getFirstName().isBlank() || profile.getLastName().isBlank() || profile.getStudentGroup().isBlank()){
+            throw new BusinessException(ErrorCode.EMPTY_FIELDS);
+        }
+    }
+    public void checkEmptyFieldsForUpdate(Profile profile){
+        if(profile.getFirstName().isBlank() || profile.getEmail().isBlank() ||profile.getLastName().isBlank() || profile.getStudentGroup().isBlank()){
+            throw new BusinessException(ErrorCode.EMPTY_FIELDS);
+        }
+    }
+
+    public void checkUniqueEmail(Profile profile){
+        String email = profile.getEmail();
+        profileRepository.findByEmail(email).ifPresent(entity -> {
+            throw new BusinessException(ErrorCode.EMAIL_ALREADY_TAKEN);
+        });
+    }
+
+    public void checkEmail(String email){ // здесь можно проверять корректность email
+        if(email.isBlank()){
+            throw new BusinessException(ErrorCode.EMPTY_FIELDS);
+        }
+    }
+
+    public ProfileEntity checkForExistence(String uuid){
+        checkUuid(uuid);
+        var id = UUID.fromString(uuid);
+        return profileRepository.findById(id).orElseThrow(() ->
+                new BusinessException(ErrorCode.PROFILE_NOT_FOUND)
+        );
+    }
+
+    public void checkUuid(String uuid){ // здесь можно проверять корректность uuid
+        if(uuid.isBlank()){
+            throw new BusinessException(ErrorCode.EMPTY_FIELDS);
+        }
+    }
+
+    public ProfileEntity checkEmailExistence(String email){
+        checkEmail(email);
+        return profileRepository.findByEmail(email).orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
+    }
+
+}

--- a/src/main/resources/proto/profile.proto
+++ b/src/main/resources/proto/profile.proto
@@ -3,9 +3,8 @@ syntax = "proto3";
 package ru.leti.wise.task.profile;
 
 enum Role {
-  STUDENT = 0;
-  TEACHER = 1;
-  CAPTAIN = 2;
+  USER = 0;
+  AUTHOR = 1;
   ADMIN = 3;
 }
 


### PR DESCRIPTION
Добавил класс валидатора ProfileValidator для профилей, который можно дополнять другими валидациями. Подправил логику UpdateProfileOperation, добавив проверку на наличие нужных полей для обновления( я так понял это email, ФИО и группа, возможно ошибаюсь), а также добавил в маппере метод для копирования из dto в profileEntity. Добавил вызовы метода валидатора во все классы пакета logic(кроме классов связанных с почтой). Протестировал каждую операцию(кроме связанных с почтой) в postman.